### PR TITLE
use modern cmake style for include directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build_*
 install_*
 source.me
+perfstubs_api/config.h

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build_*
 install_*
 source.me
-perfstubs_api/config.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,27 +133,6 @@ configure_file (
     "${PROJECT_SOURCE_DIR}/perfstubs_api/config.h.in"
     "${PROJECT_BINARY_DIR}/perfstubs_api/config.h"
     )
-configure_file (
-    "${PROJECT_SOURCE_DIR}/perfstubs_api/timer.h"
-    "${PROJECT_BINARY_DIR}/perfstubs_api/timer.h"
-    )
-configure_file (
-    "${PROJECT_SOURCE_DIR}/perfstubs_api/timer_f.h"
-    "${PROJECT_BINARY_DIR}/perfstubs_api/timer_f.h"
-    )
-configure_file (
-    "${PROJECT_SOURCE_DIR}/perfstubs_api/tool.h"
-    "${PROJECT_BINARY_DIR}/perfstubs_api/tool.h"
-    )
-# We copy all the headers in case this project is built as a git submodule.
-set(PERFSTUBS_INCLUDE_DIR ${PROJECT_BINARY_DIR} CACHE STRING "PerfStubs header location")
-set(PERFSTUBS_LIBRARY_DIR ${PROJECT_BINARY_DIR} CACHE STRING "PerfStubs library location")
-
-# add the binary tree to the search path for include files
-# so that we will find Config.h
-include_directories("${PROJECT_BINARY_DIR}")
-# Also add the source tree for all targets
-include_directories ("${PROJECT_SOURCE_DIR}")
 
 # Deal with CMP0042 warnings from CMake
 if (APPLE)
@@ -173,6 +152,16 @@ set (EXTRA_LIBS2 ${EXTRA_LIBS2} ${PTHREAD_LIB} m)
 
 add_library(perfstubs perfstubs_api/timer.c)
 add_library(perfstubs_n perfstubs_api_n/timer.c)
+
+target_include_directories(perfstubs PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
+
+target_include_directories(perfstubs_n PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
 
 # add the perfstubs library
 if (PERFSTUBS_USE_TIMERS)
@@ -198,6 +187,14 @@ if(NOT PERFSTUBS_LIBRARY_ONLY)
     if (PERFSTUBS_USE_DEFAULT_IMPLEMENTATION)
         add_library(implementation implementation/tool1_implementation.cpp)
         add_library(implementation2 implementation/tool2_implementation.cpp)
+        target_include_directories(implementation PRIVATE
+          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+          $<INSTALL_INTERFACE:include>
+        )
+        target_include_directories(implementation2 PRIVATE
+          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+          $<INSTALL_INTERFACE:include>
+        )
         if (APPLE)
             target_link_options(implementation PUBLIC -undefined dynamic_lookup)
             target_link_options(implementation2 PUBLIC -undefined dynamic_lookup)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ endif()
 # to the source code
 configure_file (
     "${PROJECT_SOURCE_DIR}/perfstubs_api/config.h.in"
-    "${PROJECT_BINARY_DIR}/perfstubs_api/config.h"
+    "${PROJECT_SOURCE_DIR}/perfstubs_api/config.h"
     )
 
 # Deal with CMP0042 warnings from CMake
@@ -418,8 +418,7 @@ install (TARGETS perfstubs perfstubs_n
 install (FILES perfstubs_api/timer.h DESTINATION include/perfstubs_api)
 install (FILES perfstubs_api/timer_f.h DESTINATION include/perfstubs_api)
 install (FILES perfstubs_api/tool.h DESTINATION include/perfstubs_api)
-install (FILES ${CMAKE_BINARY_DIR}/perfstubs_api/config.h
-    DESTINATION include/perfstubs_api)
+install (FILES perfstubs_api/config.h DESTINATION include/perfstubs_api)
 install (FILES ${CMAKE_BINARY_DIR}/perfstubs.pc DESTINATION lib/pkgconfig)
 install (FILES ${CMAKE_BINARY_DIR}/perfstubs-config.cmake
     DESTINATION lib/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ endif()
 # to the source code
 configure_file (
     "${PROJECT_SOURCE_DIR}/perfstubs_api/config.h.in"
-    "${PROJECT_SOURCE_DIR}/perfstubs_api/config.h"
+    "${PROJECT_BINARY_DIR}/perfstubs_api/config.h"
     )
 
 # Deal with CMP0042 warnings from CMake
@@ -155,11 +155,13 @@ add_library(perfstubs_n perfstubs_api_n/timer.c)
 
 target_include_directories(perfstubs PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
   $<INSTALL_INTERFACE:include>
 )
 
 target_include_directories(perfstubs_n PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
   $<INSTALL_INTERFACE:include>
 )
 
@@ -189,10 +191,12 @@ if(NOT PERFSTUBS_LIBRARY_ONLY)
         add_library(implementation2 implementation/tool2_implementation.cpp)
         target_include_directories(implementation PRIVATE
           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+          $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
           $<INSTALL_INTERFACE:include>
         )
         target_include_directories(implementation2 PRIVATE
           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+          $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
           $<INSTALL_INTERFACE:include>
         )
         if (APPLE)
@@ -418,7 +422,7 @@ install (TARGETS perfstubs perfstubs_n
 install (FILES perfstubs_api/timer.h DESTINATION include/perfstubs_api)
 install (FILES perfstubs_api/timer_f.h DESTINATION include/perfstubs_api)
 install (FILES perfstubs_api/tool.h DESTINATION include/perfstubs_api)
-install (FILES perfstubs_api/config.h DESTINATION include/perfstubs_api)
+install (FILES ${CMAKE_BINARY_DIR}/perfstubs_api/config.h DESTINATION include/perfstubs_api)
 install (FILES ${CMAKE_BINARY_DIR}/perfstubs.pc DESTINATION lib/pkgconfig)
 install (FILES ${CMAKE_BINARY_DIR}/perfstubs-config.cmake
     DESTINATION lib/cmake)


### PR DESCRIPTION
This simplifies using the libraries both internally and externally;
the user doesn't need to worry about setting include directories,
they simply use target_link_libraries(mytarget PRIVATE perfstubs),
and the include dirs are added appropriatelly for the platform and
compiler.